### PR TITLE
fix(tracker): harden foreground-service startup and handle FGS timeouts

### DIFF
--- a/tracker/api-module/src/main/res/values/strings.xml
+++ b/tracker/api-module/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="notification_stop_til_recharge">Stop till recharge</string>
     <string name="notification_tracker_active_ticker">Recording your route — location in use</string>
     <string name="notification_tracking_active">Tracking</string>
+    <string name="notification_tracking_start_failed_title">Tracking couldn\'t start</string>
+    <string name="notification_tracking_start_failed_text">Tracking couldn\'t start in the background. Open the app to resume.</string>
 
     <string name="permissions_tracker_timer_message">%1$s location method requires additional permissions to start tracking</string>
 

--- a/tracker/engine/src/main/AndroidManifest.xml
+++ b/tracker/engine/src/main/AndroidManifest.xml
@@ -32,8 +32,12 @@
         <service
             android:name="com.adsamcik.tracker.tracker.service.TrackerService"
             android:exported="false"
-            android:foregroundServiceType="location"
-            tools:targetApi="q" />
+            android:foregroundServiceType="location|specialUse"
+            tools:targetApi="q">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="SignalTracking" />
+        </service>
 
         <service
             android:name="com.adsamcik.tracker.tracker.service.ActivityWatcherService"

--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/notification/TrackerNotificationManager.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/notification/TrackerNotificationManager.kt
@@ -96,6 +96,7 @@ class TrackerNotificationManager(
 
 	companion object {
 		const val NOTIFICATION_ID: Int = -7643
+		const val START_FAILED_NOTIFICATION_ID: Int = -7644
 
 		fun getForegroundNotification(
 			context: Context,
@@ -108,6 +109,41 @@ class TrackerNotificationManager(
 				.setContentTitle(context.getString(R.string.notification_starting))
 				.setContentText(context.getString(R.string.notification_tracker_active_ticker))
 				.build()
+		}
+
+		/**
+		 * Posts a dismissible, user-visible notification informing the user that tracking
+		 * could not start (e.g. location permission was revoked or a background start was
+		 * blocked by the platform). This replaces a previously silent failure so the user
+		 * has a clear, tappable signal to reopen the app and resume tracking.
+		 */
+		fun postStartFailedNotification(context: Context) {
+			TrackerNotificationChannels.ensureTrackingChannel(context)
+			val resources = context.resources
+			val builder = NotificationCompat.Builder(
+				context,
+				resources.getString(com.adsamcik.tracker.shared.base.R.string.channel_track_id)
+			)
+				.setSmallIcon(com.adsamcik.tracker.shared.base.R.drawable.ic_signals)
+				.setCategory(NotificationCompat.CATEGORY_ERROR)
+				.setPriority(NotificationCompat.PRIORITY_DEFAULT)
+				.setContentTitle(resources.getString(R.string.notification_tracking_start_failed_title))
+				.setContentText(resources.getString(R.string.notification_tracking_start_failed_text))
+				.setAutoCancel(true)
+
+			context.packageManager.getLaunchIntentForPackage(context.packageName)?.let { launch ->
+				builder.setContentIntent(
+					TaskStackBuilder.create(context).run {
+						addNextIntentWithParentStack(launch)
+						getPendingIntent(
+							0,
+							PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE)
+						)
+					}
+				)
+			}
+
+			context.notificationManager.notify(START_FAILED_NOTIFICATION_ID, builder.build())
 		}
 
 		private fun createBuilder(context: Context, useStyle: Boolean): NotificationCompat.Builder {

--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/ActivityWatcherService.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/ActivityWatcherService.kt
@@ -7,10 +7,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.adsamcik.tracker.activity.R
 import com.adsamcik.tracker.activity.api.ActivityRequestManager
+import com.adsamcik.tracker.logger.Reporter
 import com.adsamcik.tracker.shared.base.Time
 import com.adsamcik.tracker.shared.base.data.ActivityInfo
 import com.adsamcik.tracker.shared.base.extension.notificationManager
@@ -51,9 +51,15 @@ class ActivityWatcherService : CoreService() {
 
 		val updatePreferenceInSeconds = BackgroundTrackingApi.activityFreqSeconds
 
-		startForegroundCompat(updateNotification())
+		val foregroundStarted = startForegroundCompat(updateNotification())
 
 		notificationManager = (this as Context).notificationManager
+
+		if (!foregroundStarted) {
+			Reporter.w(TAG, "Could not enter foreground; stopping activity watcher")
+			stopSelf()
+			return
+		}
 
 		BackgroundTrackingApi.initialize(this)
 		activityWatcherController.poke()
@@ -83,16 +89,37 @@ class ActivityWatcherService : CoreService() {
 		return START_REDELIVER_INTENT
 	}
 
-	private fun startForegroundCompat(notification: Notification) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-			// SPECIAL_USE foreground service type is available from Android 14.
-			startForeground(
-				NOTIFICATION_ID,
-				notification,
-				ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
-			)
-		} else {
-			startForeground(NOTIFICATION_ID, notification)
+	/**
+	 * Android 15+ may time out a foreground service of a time-limited type. Stop cleanly so
+	 * the platform does not raise a fatal `RemoteServiceException`; the watcher will be
+	 * re-poked the next time tracking state changes.
+	 */
+	override fun onTimeout(startId: Int, fgsType: Int) {
+		Reporter.w(TAG, "Activity watcher foreground service timed out (type=$fgsType); stopping")
+		stopSelf(startId)
+	}
+
+	private fun startForegroundCompat(notification: Notification): Boolean {
+		return try {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+				// SPECIAL_USE foreground service type is available from Android 14.
+				startForeground(
+					NOTIFICATION_ID,
+					notification,
+					ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+				)
+			} else {
+				startForeground(NOTIFICATION_ID, notification)
+			}
+			true
+		} catch (e: SecurityException) {
+			Reporter.report(e)
+			false
+		} catch (e: IllegalStateException) {
+			// ForegroundServiceStartNotAllowedException (Android 12+) is an
+			// IllegalStateException subclass; treat any such failure as "not foregrounded".
+			Reporter.report(e)
+			false
 		}
 	}
 

--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/TrackerService.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/TrackerService.kt
@@ -1,5 +1,6 @@
 package com.adsamcik.tracker.tracker.service
 
+import android.app.Notification
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
@@ -10,6 +11,7 @@ import com.adsamcik.tracker.shared.base.Time
 import com.adsamcik.tracker.shared.base.concurrency.DispatchersProvider
 import com.adsamcik.tracker.shared.base.database.AppDatabase
 import com.adsamcik.tracker.shared.base.extension.getSystemServiceTyped
+import com.adsamcik.tracker.shared.base.extension.hasLocationPermission
 import com.adsamcik.tracker.shared.base.service.CoreService
 import com.adsamcik.tracker.shared.preferences.settings.TrackerSettingsRepository
 import com.adsamcik.tracker.shared.preferences.tracking.TrackingParamsRepository
@@ -105,7 +107,7 @@ internal class TrackerService : CoreService(), TrackerTimerReceiver {
 	override fun onCreate() {
 		super.onCreate()
 
-		ensureForegroundStarted()
+		val foregroundStarted = ensureForegroundStarted()
 
 		powerManager = getSystemServiceTyped(Context.POWER_SERVICE)
 		wakeLock = powerManager.newWakeLock(
@@ -141,11 +143,25 @@ internal class TrackerService : CoreService(), TrackerTimerReceiver {
 				)
 			)
 		}
+
+		if (!foregroundStarted) {
+			// startForeground failed (e.g. location permission revoked or a background
+			// start was blocked). Stop cleanly instead of lingering as a started-but-not-
+			// foreground service that the platform would later kill.
+			stopSelf()
+		}
 	}
 
 	override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 		super.onStartCommand(intent, flags, startId)
-		ensureForegroundStarted()
+		if (!ensureForegroundStarted()) {
+			Reporter.w(
+				"TrackerService",
+				"Could not enter foreground (missing permission or blocked background start); stopping"
+			)
+			stopSelfResult(startId)
+			return START_NOT_STICKY
+		}
 
 		val recoveredSessionInfo = sessionInfo ?: controller.sessionInfoFlow.value
 		val resolvedIntent = intent ?: run {
@@ -242,20 +258,66 @@ internal class TrackerService : CoreService(), TrackerTimerReceiver {
 		return if (isUserInitiated) START_STICKY else START_NOT_STICKY
 	}
 
-	private fun ensureForegroundStarted() {
+	/**
+	 * Promotes the service to the foreground, choosing a foreground-service type that
+	 * matches the permissions actually held:
+	 *  - [ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION] when a location permission is
+	 *    granted (GPS sessions), and
+	 *  - [ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE] as a fallback so Wi-Fi/cell/
+	 *    activity-only ("ambient") sessions can still run when location permission is absent.
+	 *
+	 * Starting a location-typed foreground service without a location permission throws a
+	 * [SecurityException] on Android 14+, and any blocked background start throws
+	 * `ForegroundServiceStartNotAllowedException` (an [IllegalStateException] subclass) on
+	 * Android 12+. Both are caught so a failed start surfaces a user-visible notification and
+	 * a clean stop instead of an uncaught crash or a silent no-op.
+	 *
+	 * @return true if the service is now in the foreground, false if it could not be started.
+	 */
+	private fun ensureForegroundStarted(): Boolean {
 		TrackerNotificationChannels.ensureTrackingChannel(this)
 		val notification = TrackerNotificationManager.getForegroundNotification(this)
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-			startForeground(
-				TrackerNotificationManager.NOTIFICATION_ID,
-				notification,
-				ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
-			)
+
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+			return tryStartForeground(notification, fgsType = null)
+		}
+
+		val preferredType = if (hasLocationPermission) {
+			ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 		} else {
-			startForeground(
-				TrackerNotificationManager.NOTIFICATION_ID,
-				notification
-			)
+			ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+		}
+		if (tryStartForeground(notification, preferredType)) return true
+
+		// If the location type was rejected (e.g. permission revoked between the check and
+		// the start call), fall back to the special-use type before giving up.
+		if (preferredType != ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE &&
+			tryStartForeground(notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+		) {
+			return true
+		}
+
+		TrackerNotificationManager.postStartFailedNotification(this)
+		return false
+	}
+
+	private fun tryStartForeground(notification: Notification, fgsType: Int?): Boolean {
+		return try {
+			if (fgsType != null) {
+				startForeground(TrackerNotificationManager.NOTIFICATION_ID, notification, fgsType)
+			} else {
+				startForeground(TrackerNotificationManager.NOTIFICATION_ID, notification)
+			}
+			true
+		} catch (e: SecurityException) {
+			// Missing runtime permission for the requested FGS type (Android 14+).
+			Reporter.report(e)
+			false
+		} catch (e: IllegalStateException) {
+			// ForegroundServiceStartNotAllowedException (Android 12+) is an
+			// IllegalStateException subclass; also covers an already-stopped service.
+			Reporter.report(e)
+			false
 		}
 	}
 
@@ -287,6 +349,17 @@ internal class TrackerService : CoreService(), TrackerTimerReceiver {
 			)
 			TrackerTimerErrorSeverity.WARNING -> Reporter.log(errorData.internalMessage)
 		}
+	}
+
+	/**
+	 * Android 15+ may time out a foreground service of a time-limited type. Stop cleanly so
+	 * the platform does not raise a fatal `RemoteServiceException`; the normal [onDestroy]
+	 * cleanup then flushes the durable signal buffer. Auto-tracking sessions can be
+	 * re-triggered by [ActivityWatcherService]; user sessions end gracefully.
+	 */
+	override fun onTimeout(startId: Int, fgsType: Int) {
+		Reporter.w("TrackerService", "Foreground service timed out (type=$fgsType); stopping")
+		stopSelf(startId)
 	}
 
 	override fun onDestroy() {


### PR DESCRIPTION
## Summary

Hardens foreground-service startup and adds Android 15+ FGS-timeout handling for `TrackerService` and `ActivityWatcherService`. Part of the tracking-architecture review follow-ups (FGS robustness / platform compliance).

On the current `dev/v10` code, `TrackerService` always calls `startForeground(..., FOREGROUND_SERVICE_TYPE_LOCATION)` with **no permission gating and no exception handling**. That means:
- if the location permission isn't held, the location-typed FGS start throws `SecurityException` on Android 14+ (uncaught crash), and
- a blocked background start throws `ForegroundServiceStartNotAllowedException` (Android 12+) — also uncaught.

Neither service implements `Service.onTimeout()`, so a platform FGS time-out would surface as a fatal `RemoteServiceException`.

## Changes

**Robust FGS startup (`TrackerService`)**
- `ensureForegroundStarted()` now returns `Boolean` and selects the FGS type by held permission: `LOCATION` when a location permission is granted, else `SPECIAL_USE`. This lets Wi-Fi/cell/activity-only ("ambient") sessions run when location permission is absent — and is also more accurate per Play policy, since a no-GPS session shouldn't declare itself a `location` FGS.
- `startForeground` is wrapped (`tryStartForeground`) catching `SecurityException` and `IllegalStateException` (the supertype of `ForegroundServiceStartNotAllowedException`, avoiding an API-31 type reference). On total failure it posts a **user-visible, dismissible notification** ("Tracking couldn't start — open the app to resume") and stops cleanly instead of crashing or silently no-oping.
- `onCreate` / `onStartCommand` react to the boolean (stop cleanly on failure).

**Manifest**
- `TrackerService` now declares `android:foregroundServiceType="location|specialUse"` plus `PROPERTY_SPECIAL_USE_FGS_SUBTYPE="SignalTracking"` so the special-use fallback is legal. `FOREGROUND_SERVICE_SPECIAL_USE` was already declared and `ActivityWatcherService` already uses `specialUse`.

**`onTimeout()` (Android 15+, API 35)**
- Implemented in both `TrackerService` and `ActivityWatcherService`: report + `stopSelf(startId)`. The normal `onDestroy` cleanup still flushes the durable signal buffer; auto-tracking is re-triggered by `ActivityWatcherService`.

**`ActivityWatcherService`**
- `startForegroundCompat` returns `Boolean` + try/catch; stops cleanly on failure. Removed an unused `android.util.Log` import.

## Verification
- `./gradlew :tracker:engine:compileDebugKotlin` — **BUILD SUCCESSFUL**.
- Unit tests not run locally (the engine's JUnit5 + Robolectric tests fail locally with "No instrumentation registered"); CI will run them.

## Reviewer decision point
Adding `specialUse` to `TrackerService`'s declared types broadens the FGS-type surface. It's consistent with the existing `ActivityWatcherService` special-use usage and the app's already-declared `FOREGROUND_SERVICE_SPECIAL_USE` permission, and it fixes a latent policy mismatch (ambient sessions previously declared `location`). Flagging it explicitly in case you'd prefer to keep this PR purely defensive (drop the type fallback + manifest change) and handle ambient-FGS-type separately.

## Notes
Draft — opened for review per the "extensive review before merge" workflow.
