### PR TITLE
feat(tracker): resilient user-session restart + previous-exit classification

### DIFF
--- a/app/src/main/java/com/adsamcik/tracker/app/Application.kt
+++ b/app/src/main/java/com/adsamcik/tracker/app/Application.kt
@@ -1,5 +1,7 @@
 package com.adsamcik.tracker.app
 
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
 import android.os.Build
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
@@ -186,6 +188,7 @@ class Application : AndroidApplication(), Configuration.Provider {
 				Reporter.initialize(this@Application)
 				Logger.initialize(this@Application)
 				CrashHandler(this@Application).initialize()
+				logPreviousExitReason()
 				if (!isRobolectricUnitTest()) {
 					initializeModules()
 				}
@@ -198,6 +201,51 @@ class Application : AndroidApplication(), Configuration.Provider {
 	}
 
 	private fun isRobolectricUnitTest(): Boolean = Build.FINGERPRINT == "robolectric"
+
+	/**
+	 * Logs the reason the previous process instance exited (Android 10+/API 30) so abnormal
+	 * terminations — low-memory kills, OEM/SIGKILL, ANRs, native crashes — become observable
+	 * in crash reports. This is the foundation for crash-informed recovery (e.g. draining the
+	 * durable signal buffer after an abnormal kill) and for respecting a user-requested
+	 * force-stop (REASON_USER_REQUESTED) instead of auto-restarting tracking.
+	 */
+	@WorkerThread
+	private fun logPreviousExitReason() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+		try {
+			val activityManager = getSystemService(ActivityManager::class.java) ?: return
+			val exitInfo = activityManager
+				.getHistoricalProcessExitReasons(packageName, 0, 1)
+				.firstOrNull() ?: return
+
+			val reasonLabel = when (exitInfo.reason) {
+				ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+				ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+				ApplicationExitInfo.REASON_CRASH -> "CRASH"
+				ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+				ApplicationExitInfo.REASON_ANR -> "ANR"
+				ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+				ApplicationExitInfo.REASON_USER_STOPPED -> "USER_STOPPED"
+				ApplicationExitInfo.REASON_OTHER -> "OTHER"
+				else -> "reason=${exitInfo.reason}"
+			}
+
+			val isAbnormal = when (exitInfo.reason) {
+				ApplicationExitInfo.REASON_LOW_MEMORY,
+				ApplicationExitInfo.REASON_SIGNALED,
+				ApplicationExitInfo.REASON_CRASH,
+				ApplicationExitInfo.REASON_CRASH_NATIVE,
+				ApplicationExitInfo.REASON_ANR -> true
+				else -> false
+			}
+
+			val message = "Previous process exit: $reasonLabel (status=${exitInfo.status})"
+			if (isAbnormal) Reporter.w("App", message) else Reporter.log(message)
+		} catch (e: RuntimeException) {
+			// Defensive: getHistoricalProcessExitReasons can throw on some OEM builds.
+			Reporter.report(e)
+		}
+	}
 
 	fun startDeferredStartupIfNeeded() {
 		if (!deferredStartupStarted.compareAndSet(false, true)) return

--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/TrackerService.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/service/TrackerService.kt
@@ -237,9 +237,12 @@ internal class TrackerService : CoreService(), TrackerTimerReceiver {
 			}
 		}
 
-		// User-initiated sessions should restart after process death to preserve tracking.
-		// Auto-tracking sessions can be re-triggered by ActivityWatcherService.
-		return if (isUserInitiated) START_STICKY else START_NOT_STICKY
+		// User-initiated sessions use START_REDELIVER_INTENT so that, after a system kill,
+		// Android re-delivers the ORIGINAL start intent (carrying ARG_IS_USER_INITIATED)
+		// instead of a null intent — letting the session resume with the correct flags
+		// rather than relying on the in-memory recovery fallback below. Auto-tracking
+		// sessions stay START_NOT_STICKY and are re-triggered by ActivityWatcherService.
+		return if (isUserInitiated) START_REDELIVER_INTENT else START_NOT_STICKY
 	}
 
 	private fun ensureForegroundStarted() {


### PR DESCRIPTION
## Summary

Process-death resilience follow-ups from the tracking-architecture review (P0). Two focused, low-risk changes.

### 1. `START_REDELIVER_INTENT` for user sessions
On `dev/v10`, `TrackerService` returns `START_STICKY` for user-initiated sessions. After a system kill, `START_STICKY` re-creates the service with a **null** intent, so the original `ARG_IS_USER_INITIATED` flag is lost and the code must fall back to in-memory recovery (`sessionInfo` / `controller.sessionInfoFlow`), which is gone after a full process kill.

Switching to `START_REDELIVER_INTENT` makes Android re-deliver the **original** start intent (with its extras) on restart, so the session resumes with the correct flags. This is the pattern OsmAnd's `NavigationService` uses. Auto-tracking sessions remain `START_NOT_STICKY` (re-triggered by `ActivityWatcherService`).

### 2. `ApplicationExitInfo` previous-exit classification
`Application` now queries `ActivityManager.getHistoricalProcessExitReasons()` (API 30+) at startup and logs the previous exit reason, distinguishing **abnormal** terminations (LOW_MEMORY / SIGNALED / CRASH / CRASH_NATIVE / ANR) from normal ones (USER_REQUESTED, USER_STOPPED, OTHER). Defensive try/catch (some OEM builds throw).

This makes OEM/low-memory kills observable in crash reports and is the foundation for:
- crash-informed recovery (drain the durable signal buffer after an abnormal kill), and
- respecting a user-requested force-stop instead of auto-restarting.

## Verification
- `./gradlew :app:compileDebugKotlin` — **BUILD SUCCESSFUL**.
- Unit tests not run locally (engine JUnit5+Robolectric "No instrumentation registered"); CI will run them.

## Follow-up (filed separately)
The heavier P0 item — a **durable active-session descriptor** + an `onTaskRemoved`/`onDestroy` **restart watchdog** (GPSLogger `RestarterReceiver` pattern) + wiring `ApplicationExitInfo` into an automatic WAL-drain worker — is tracked as a separate issue because it needs on-device validation (restart-loop / battery safety) that can't be done from a compile check.

## Notes
Draft — opened for review.
