### PR TITLE
chore(tracker): log WorkManager stop reasons and persistence errors

### DIFF
--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/pipeline/persistence/PersistenceProcessor.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/pipeline/persistence/PersistenceProcessor.kt
@@ -1,6 +1,7 @@
 package com.adsamcik.tracker.tracker.pipeline.persistence
 
 import android.util.Log
+import com.adsamcik.tracker.logger.Reporter
 import com.adsamcik.tracker.shared.base.Time
 import com.adsamcik.tracker.shared.base.database.dao.ActivitySnapshotDao
 import com.adsamcik.tracker.shared.base.database.dao.CellSampleDao
@@ -325,6 +326,10 @@ class PersistenceProcessor @Inject constructor(
 				throw e
 			} catch (e: Exception) {
 				Log.w(TAG, "Flush failed for $tableName chunk $index (${chunk.size} records)", e)
+				// Route to the redacting crash reporter so DB persistence failures are visible
+				// in diagnostics, not just logcat. The structured errorCollector flow below is
+				// exposed via the controller but currently observed only by optional UI.
+				Reporter.report(e)
 				errorCollector.reportError(
 					PersistenceError(
 						source = PROCESSOR_ID,

--- a/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/worker/DailySummaryMaterializationWorker.kt
+++ b/tracker/engine/src/main/java/com/adsamcik/tracker/tracker/worker/DailySummaryMaterializationWorker.kt
@@ -11,10 +11,12 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.adsamcik.tracker.shared.base.database.AppDatabase
 import com.adsamcik.tracker.shared.base.database.aggregator.DailySummaryAggregator
+import com.adsamcik.tracker.logger.Reporter
 import com.adsamcik.tracker.stats.api.metric.MetricDirtyTracker
 import com.adsamcik.tracker.stats.api.metric.MetricKeys
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -39,18 +41,30 @@ class DailySummaryMaterializationWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, workerParams) {
 
 	override suspend fun doWork(): Result {
-		val database = AppDatabase.database(applicationContext)
-		val aggregator = DailySummaryAggregator(
-			dailySummaryDao = database.dailySummaryDao(),
-			sessionSegmentDao = database.sessionSegmentDao(),
-			onDailySummaryWritten = {
-				dirtyTracker.markDirty(MetricKeys.TABLE_DAILY_SUMMARY)
-			},
-		)
+		try {
+			val database = AppDatabase.database(applicationContext)
+			val aggregator = DailySummaryAggregator(
+				dailySummaryDao = database.dailySummaryDao(),
+				sessionSegmentDao = database.sessionSegmentDao(),
+				onDailySummaryWritten = {
+					dirtyTracker.markDirty(MetricKeys.TABLE_DAILY_SUMMARY)
+				},
+			)
 
-		aggregator.materializeToday()
+			aggregator.materializeToday()
 
-		return Result.success()
+			return Result.success()
+		} catch (e: CancellationException) {
+			// The system stopped this worker before completion — e.g. Android 16 job-quota
+			// throttling (jobs now count against quota even while an FGS runs), constraints no
+			// longer met, or the app was killed. Log the stop reason so quota-related stops are
+			// diagnosable, then propagate cancellation so WorkManager can reschedule.
+			Reporter.w(
+				"DailySummaryMaterializationWorker",
+				"Stopped before completion (stopReason=$stopReason)"
+			)
+			throw e
+		}
 	}
 
 	companion object {


### PR DESCRIPTION
## Summary

Observability follow-ups from the tracking-architecture review (P1/P3). Two small, additive, low-risk changes in `:tracker:engine`.

### 1. WorkManager stop-reason logging (Android 16 quota)
`DailySummaryMaterializationWorker.doWork()` now catches `CancellationException` and logs `getStopReason()` before re-throwing. Android 16 (API 36) made JobScheduler/WorkManager jobs count against the app's standby-bucket quota **even while a foreground service is running**, so this worker can now be throttled. Logging the stop reason makes quota-related stops diagnosable (`STOP_REASON_QUOTA`, `STOP_REASON_CONSTRAINT_*`, etc.). Cancellation still propagates so WorkManager reschedules as before — success/failure semantics are unchanged.

### 2. Route persistence errors to the crash reporter
`PersistenceProcessor.flushTable()` already logged DB flush failures to logcat (`Log.w`) and to a structured `PersistenceErrorCollector` flow — but that flow is exposed via the controller and **consumed by no production code** (only tests). It now also calls `Reporter.report(e)`, so persistence failures reach the redacting crash reporter and become visible in diagnostics.

## Verification
- `./gradlew :tracker:engine:compileDebugKotlin` — **BUILD SUCCESSFUL**.
- `Reporter` is safe to call before init (no-ops), so existing unit tests are unaffected.
- WorkManager `2.11.1` supports `getStopReason()` (added 2.9.0).

## Notes
Draft — opened for review. Broader `getStopReason()` logging in the other app workers (`DatabaseMaintenanceWorker`, `GoalNotificationWorker`, retention) is intentionally out of scope to keep this PR within one module.
